### PR TITLE
Fix ApiException typos in API files

### DIFF
--- a/lib/API/mutations.dart
+++ b/lib/API/mutations.dart
@@ -53,7 +53,7 @@ Future<T> create<T extends Model>(T model) async {
     return response.data as T;
   } on ApiException catch (e) {
     debugPrint(
-        'ApiExecption: create ${model.runtimeType} with ${model.modelIdentifier} failed: $e');
+        'ApiException: create ${model.runtimeType} with ${model.modelIdentifier} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint(
@@ -72,7 +72,7 @@ Future<T> update<T extends Model>(T model) async {
     return response.data as T;
   } on ApiException catch (e) {
     debugPrint(
-        'ApiExecption: update ${model.runtimeType} with ${model.modelIdentifier} failed: $e');
+        'ApiException: update ${model.runtimeType} with ${model.modelIdentifier} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint(
@@ -91,7 +91,7 @@ Future<T> delete<T extends Model>(T model) async {
     return response.data as T;
   } on ApiException catch (e) {
     debugPrint(
-        'ApiExecption: delete ${model.runtimeType} with ${model.modelIdentifier} failed: $e');
+        'ApiException: delete ${model.runtimeType} with ${model.modelIdentifier} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint(

--- a/lib/pages/admin/aircraft/api.dart
+++ b/lib/pages/admin/aircraft/api.dart
@@ -32,7 +32,7 @@ Future<Aircraft> deleteAicraft(Aircraft aircraft) async {
     await Future.wait(futures);
     return aircraft;
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: delete Aircraft with ${aircraft.id} failed: $e');
+    debugPrint('ApiException: delete Aircraft with ${aircraft.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint(

--- a/lib/pages/admin/categories/api.dart
+++ b/lib/pages/admin/categories/api.dart
@@ -15,7 +15,7 @@ Future<Category> deleteCategory(Category category) async {
     await Future.wait(futures);
     return category;
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: delete Category with ${category.id} failed: $e');
+    debugPrint('ApiException: delete Category with ${category.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint(

--- a/lib/pages/admin/categories/subcategories/api.dart
+++ b/lib/pages/admin/categories/subcategories/api.dart
@@ -34,7 +34,7 @@ Future<Subcategory> deleteSubcategory(Subcategory subcategory) async {
     return subcategory;
   } on ApiException catch (e) {
     debugPrint(
-        'ApiExecption: delete Subcategory with ${subcategory.id} failed: $e');
+        'ApiException: delete Subcategory with ${subcategory.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint(
@@ -79,7 +79,7 @@ Future<void> updateStaffSubcategory(
     }
     await Future.wait(futures);
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: update StaffSubcategory failed: $e');
+    debugPrint('ApiException: update StaffSubcategory failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: update StaffSubcategory failed: $e');

--- a/lib/pages/admin/roles/api.dart
+++ b/lib/pages/admin/roles/api.dart
@@ -20,7 +20,7 @@ Future<Role> deleteRole(Role role) async {
     await Future.wait(futures);
     return role;
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: delete Role with ${role.id} failed: $e');
+    debugPrint('ApiException: delete Role with ${role.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: delete Role with ${role.id} failed: $e');

--- a/lib/pages/admin/roles/crew_document_categories/api.dart
+++ b/lib/pages/admin/roles/crew_document_categories/api.dart
@@ -32,7 +32,7 @@ Future<FlightCrewRecordCategory> deleteFlightCrewRecordsCategory(
     return category;
   } on ApiException catch (e) {
     debugPrint(
-        'ApiExecption: delete Flight Crew Records Category with ${category.id} failed: $e');
+        'ApiException: delete Flight Crew Records Category with ${category.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint(

--- a/lib/pages/admin/staff/api.dart
+++ b/lib/pages/admin/staff/api.dart
@@ -98,7 +98,7 @@ Future<Staff> deleteStaff(Staff staff) async {
     await Future.wait(futures);
     return staff;
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: delete Staff with ${staff.id} failed: $e');
+    debugPrint('ApiException: delete Staff with ${staff.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: delete Staff with ${staff.id} failed: $e');
@@ -124,7 +124,7 @@ Future<void> updateAircraftStaff(Staff staff, List<Aircraft> aircraft) async {
     }
     await Future.wait(futures);
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: update AircraftStaff failed: $e');
+    debugPrint('ApiException: update AircraftStaff failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: update AircraftStaff failed: $e');
@@ -153,7 +153,7 @@ Future<void> updateRoleStaff(Staff staff, List<Role> roles) async {
 
     await Future.wait(futures);
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: update RoleStaff failed: $e');
+    debugPrint('ApiException: update RoleStaff failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: update RoleStaff failed: $e');
@@ -194,7 +194,7 @@ Future<void> updateStaffSubcategory(
     }
     await Future.wait(futures);
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: update RoleStaff failed: $e');
+    debugPrint('ApiException: update RoleStaff failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: update RoleStaff failed: $e');

--- a/lib/pages/main/cms/view_cms/api.dart
+++ b/lib/pages/main/cms/view_cms/api.dart
@@ -28,7 +28,7 @@ Future<Report> deleteReport(Report report) async {
     await Future.wait(futures);
     return report;
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: delete Report with ${report.id} failed: $e');
+    debugPrint('ApiException: delete Report with ${report.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: delete Report with ${report.id} failed: $e');

--- a/lib/pages/main/sms/view_sms/api.dart
+++ b/lib/pages/main/sms/view_sms/api.dart
@@ -36,7 +36,7 @@ Future<Notice> deleteNotice(Notice notice) async {
     await Future.wait(futures);
     return notice;
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: delete Notice with ${notice.id} failed: $e');
+    debugPrint('ApiException: delete Notice with ${notice.id} failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: delete Notice with ${notice.id} failed: $e');
@@ -124,7 +124,7 @@ Future<Iterable<Staff>> fetchJoinRecipients({
       return map;
     }).values;
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: fetchJoinRecipients failed: $e');
+    debugPrint('ApiException: fetchJoinRecipients failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: fetchJoinRecipients failed: $e');
@@ -175,7 +175,7 @@ Future<void> updateNoticeStaff(
       ),
     ]);
   } on ApiException catch (e) {
-    debugPrint('ApiExecption: send notice failed: $e');
+    debugPrint('ApiException: send notice failed: $e');
     rethrow;
   } on Exception catch (e) {
     debugPrint('Dart Exception: send notice failed: $e');


### PR DESCRIPTION
## Summary
- replace `ApiExecption` with `ApiException` in mutations and various API helpers

## Testing
- `dart format lib/API/mutations.dart lib/pages/admin/aircraft/api.dart lib/pages/admin/roles/crew_document_categories/api.dart lib/pages/admin/roles/api.dart lib/pages/admin/categories/api.dart lib/pages/admin/categories/subcategories/api.dart lib/pages/admin/staff/api.dart lib/pages/main/cms/view_cms/api.dart lib/pages/main/sms/view_sms/api.dart` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `dart analyze` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a6d771c3648327baffd0183fafc8f9